### PR TITLE
add .iml file to fix busted intellij module

### DIFF
--- a/html_builder.iml
+++ b/html_builder.iml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+    </content>
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Dart SDK" level="project" />
+    <orderEntry type="library" name="Dart Packages" level="project" />
+  </component>
+</module>


### PR DESCRIPTION
because the [`.idea/modules.xml`](https://github.com/mariposa-dart/html_builder/blob/master/.idea/modules.xml) file is committed, the `.iml` file it refers to needs to alos be committed, otherwise the project folders get hidden:

![image](https://user-images.githubusercontent.com/57028336/178143710-4105c497-bc6c-4ee8-ab7a-26d3fedd4306.png)

more info: https://youtrack.jetbrains.com/issue/IDEA-281089/directories-not-visible-in-project-view-when-iml-file-cant-be-found